### PR TITLE
Merged branch 'master' of ezsystems/ezplatform-automated-translation into 4.3

### DIFF
--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -1,0 +1,10 @@
+name: Assign Pull Request to maintainers
+
+on:
+    pull_request_target:
+
+jobs:
+    assign:
+        uses: ibexa/gh-workflows/.github/workflows/pr-assign.yml@main
+        secrets:
+            robot-token: ${{ secrets.EZROBOT_PAT }}


### PR DESCRIPTION
Looks like we don't have cross-merge workflow for this repo.

Cross merge of https://github.com/ezsystems/ezplatform-automated-translation/pull/28