### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -38,14 +38,22 @@
         "ibexa/admin-ui": "~5.0.0@dev"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.2",
-        "phpmd/phpmd": "^2.6",
-        "phpunit/phpunit": "^8.5",
-        "ibexa/code-style": "^1.0",
         "dg/bypass-finals": "^1.3",
+        "ibexa/code-style": "^1.0",
+        "ibexa/content-forms": "~5.0.x-dev",
+        "ibexa/design-engine": "~5.0.x-dev",
+        "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/http-cache": "~5.0.x-dev",
+        "ibexa/notifications": "~5.0.x-dev",
+        "ibexa/rest": "~5.0.x-dev",
+        "ibexa/search": "~5.0.x-dev",
+        "ibexa/user": "~5.0.x-dev",
+        "phpmd/phpmd": "^2.6",
         "phpstan/phpstan": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpstan/phpstan-symfony": "^1.0"
+        "phpstan/phpstan-symfony": "^1.0",
+        "phpunit/phpunit": "^8.5",
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -59,17 +59,13 @@
         "psr-4": {
             "Ibexa\\AutomatedTranslation\\": "src/lib/",
             "Ibexa\\Bundle\\AutomatedTranslation\\": "src/bundle/",
-            "Ibexa\\Contracts\\AutomatedTranslation\\": "src/contracts/",
-            "EzSystems\\EzPlatformAutomatedTranslation\\": "src/lib/",
-            "EzSystems\\EzPlatformAutomatedTranslationBundle\\": "src/bundle/"
+            "Ibexa\\Contracts\\AutomatedTranslation\\": "src/contracts/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "Ibexa\\Tests\\AutomatedTranslation\\": "tests/lib/",
-            "Ibexa\\Tests\\Bundle\\AutomatedTranslation\\": "tests/bundle/",
-            "EzSystems\\EzPlatformAutomatedTranslation\\Tests\\": "tests/lib/",
-            "EzSystems\\EzPlatformAutomatedTranslationBundle\\Tests\\": "tests/bundle/"
+            "Ibexa\\Tests\\Bundle\\AutomatedTranslation\\": "tests/bundle/"
         }
     },
     "scripts": {

--- a/src/bundle/Command/TranslateContentCommand.php
+++ b/src/bundle/Command/TranslateContentCommand.php
@@ -90,5 +90,3 @@ final class TranslateContentCommand extends Command
         );
     }
 }
-
-class_alias(TranslateContentCommand::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Command\TranslateContentCommand');

--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -92,5 +92,3 @@ final class TranslationController extends Controller
         return 1 === preg_match("#{$pattern}#", $targetUrl);
     }
 }
-
-class_alias(TranslationController::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Controller\TranslationController');

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -27,5 +27,3 @@ class Configuration extends SiteAccessAware\Configuration
         return $treeBuilder;
     }
 }
-
-class_alias(Configuration::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\DependencyInjection\Configuration');

--- a/src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php
+++ b/src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php
@@ -94,5 +94,3 @@ class IbexaAutomatedTranslationExtension extends Extension implements PrependExt
         ]);
     }
 }
-
-class_alias(IbexaAutomatedTranslationExtension::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\DependencyInjection\EzPlatformAutomatedTranslationExtension');

--- a/src/bundle/Event/FieldDecodeEvent.php
+++ b/src/bundle/Event/FieldDecodeEvent.php
@@ -70,5 +70,3 @@ final class FieldDecodeEvent
         $this->previousValue = $previousValue;
     }
 }
-
-class_alias(FieldDecodeEvent::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Event\FieldDecodeEvent');

--- a/src/bundle/Event/FieldEncodeEvent.php
+++ b/src/bundle/Event/FieldEncodeEvent.php
@@ -46,5 +46,3 @@ final class FieldEncodeEvent
         $this->value = $value;
     }
 }
-
-class_alias(FieldEncodeEvent::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Event\FieldEncodeEvent');

--- a/src/bundle/EventListener/ContentProxyTranslateListener.php
+++ b/src/bundle/EventListener/ContentProxyTranslateListener.php
@@ -90,5 +90,3 @@ class ContentProxyTranslateListener implements EventSubscriberInterface
         $event->setResponse($response);
     }
 }
-
-class_alias(ContentProxyTranslateListener::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\EventListener\ContentProxyTranslateListener');

--- a/src/bundle/Events.php
+++ b/src/bundle/Events.php
@@ -20,5 +20,3 @@ final class Events
      */
     public const POST_FIELD_DECODE = 'ibexa.automated_translation.post_field_decode';
 }
-
-class_alias(Events::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Events');

--- a/src/bundle/Form/Data/TranslationAddData.php
+++ b/src/bundle/Form/Data/TranslationAddData.php
@@ -27,5 +27,3 @@ class TranslationAddData extends BaseTranslationAddData
         $this->translatorAlias = $translatorAlias;
     }
 }
-
-class_alias(TranslationAddData::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Form\Data\TranslationAddData');

--- a/src/bundle/Form/Extension/ContentEditType.php
+++ b/src/bundle/Form/Extension/ContentEditType.php
@@ -96,5 +96,3 @@ class ContentEditType extends AbstractTypeExtension
         );
     }
 }
-
-class_alias(ContentEditType::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Form\Extension\ContentEditType');

--- a/src/bundle/Form/Extension/LanguageCreateType.php
+++ b/src/bundle/Form/Extension/LanguageCreateType.php
@@ -47,5 +47,3 @@ class LanguageCreateType extends AbstractTypeExtension
         );
     }
 }
-
-class_alias(LanguageCreateType::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Form\Extension\LanguageCreateType');

--- a/src/bundle/Form/Extension/TranslationAddType.php
+++ b/src/bundle/Form/Extension/TranslationAddType.php
@@ -133,5 +133,3 @@ class TranslationAddType extends AbstractTypeExtension
         $resolver->setDefaults([]);
     }
 }
-
-class_alias(TranslationAddType::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Form\Extension\TranslationAddType');

--- a/src/bundle/Form/TranslationAddDataTransformer.php
+++ b/src/bundle/Form/TranslationAddDataTransformer.php
@@ -33,5 +33,3 @@ class TranslationAddDataTransformer implements DataTransformerInterface
         return $value;
     }
 }
-
-class_alias(TranslationAddDataTransformer::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Form\TranslationAddDataTransformer');

--- a/src/bundle/IbexaAutomatedTranslationBundle.php
+++ b/src/bundle/IbexaAutomatedTranslationBundle.php
@@ -23,5 +23,3 @@ class IbexaAutomatedTranslationBundle extends Bundle
         parent::build($container);
     }
 }
-
-class_alias(IbexaAutomatedTranslationBundle::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\EzPlatformAutomatedTranslationBundle');

--- a/src/contracts/Client/ClientInterface.php
+++ b/src/contracts/Client/ClientInterface.php
@@ -29,5 +29,3 @@ interface ClientInterface
      */
     public function getServiceFullName(): string;
 }
-
-class_alias(ClientInterface::class, 'EzSystems\EzPlatformAutomatedTranslation\Client\ClientInterface');

--- a/src/contracts/Encoder/BlockAttribute/BlockAttributeEncoderInterface.php
+++ b/src/contracts/Encoder/BlockAttribute/BlockAttributeEncoderInterface.php
@@ -21,5 +21,3 @@ interface BlockAttributeEncoderInterface
 
     public function decode(string $value): string;
 }
-
-class_alias(BlockAttributeEncoderInterface::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\BlockAttribute\BlockAttributeEncoderInterface');

--- a/src/contracts/Encoder/Field/FieldEncoderInterface.php
+++ b/src/contracts/Encoder/Field/FieldEncoderInterface.php
@@ -24,5 +24,3 @@ interface FieldEncoderInterface
      */
     public function decode(string $value, $previousFieldValue): Value;
 }
-
-class_alias(FieldEncoderInterface::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\Field\FieldEncoderInterface');

--- a/src/lib/Client/Deepl.php
+++ b/src/lib/Client/Deepl.php
@@ -90,5 +90,3 @@ class Deepl implements ClientInterface
      */
     private const LANGUAGE_CODES = ['EN', 'DE', 'FR', 'ES', 'IT', 'NL', 'PL'];
 }
-
-class_alias(Deepl::class, 'EzSystems\EzPlatformAutomatedTranslation\Client\Deepl');

--- a/src/lib/Client/Google.php
+++ b/src/lib/Client/Google.php
@@ -121,5 +121,3 @@ class Google implements ClientInterface, LoggerAwareInterface
         throw new InvalidLanguageCodeException($languageCode, $this->getServiceAlias());
     }
 }
-
-class_alias(Google::class, 'EzSystems\EzPlatformAutomatedTranslation\Client\Google');

--- a/src/lib/ClientProvider.php
+++ b/src/lib/ClientProvider.php
@@ -66,5 +66,3 @@ class ClientProvider
         return $this->clients;
     }
 }
-
-class_alias(ClientProvider::class, 'EzSystems\EzPlatformAutomatedTranslation\ClientProvider');

--- a/src/lib/Encoder.php
+++ b/src/lib/Encoder.php
@@ -208,5 +208,3 @@ class Encoder
         return $event->getValue();
     }
 }
-
-class_alias(Encoder::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder');

--- a/src/lib/Encoder/BlockAttribute/BlockAttributeEncoderManager.php
+++ b/src/lib/Encoder/BlockAttribute/BlockAttributeEncoderManager.php
@@ -61,5 +61,3 @@ final class BlockAttributeEncoderManager
         );
     }
 }
-
-class_alias(BlockAttributeEncoderManager::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\BlockAttribute\BlockAttributeEncoderManager');

--- a/src/lib/Encoder/BlockAttribute/RichTextBlockAttributeEncoder.php
+++ b/src/lib/Encoder/BlockAttribute/RichTextBlockAttributeEncoder.php
@@ -50,5 +50,3 @@ final class RichTextBlockAttributeEncoder implements BlockAttributeEncoderInterf
         return $decodedValue;
     }
 }
-
-class_alias(RichTextBlockAttributeEncoder::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\BlockAttribute\RichTextBlockAttributeEncoder');

--- a/src/lib/Encoder/BlockAttribute/TextBlockAttributeEncoder.php
+++ b/src/lib/Encoder/BlockAttribute/TextBlockAttributeEncoder.php
@@ -34,5 +34,3 @@ final class TextBlockAttributeEncoder implements BlockAttributeEncoderInterface
         return $value;
     }
 }
-
-class_alias(TextBlockAttributeEncoder::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\BlockAttribute\TextBlockAttributeEncoder');

--- a/src/lib/Encoder/Field/FieldEncoderManager.php
+++ b/src/lib/Encoder/Field/FieldEncoderManager.php
@@ -63,5 +63,3 @@ final class FieldEncoderManager
         );
     }
 }
-
-class_alias(FieldEncoderManager::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\Field\FieldEncoderManager');

--- a/src/lib/Encoder/Field/PageBuilderFieldEncoder.php
+++ b/src/lib/Encoder/Field/PageBuilderFieldEncoder.php
@@ -150,5 +150,3 @@ final class PageBuilderFieldEncoder implements FieldEncoderInterface
         return $value;
     }
 }
-
-class_alias(PageBuilderFieldEncoder::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\Field\PageBuilderFieldEncoder');

--- a/src/lib/Encoder/Field/RichTextFieldEncoder.php
+++ b/src/lib/Encoder/Field/RichTextFieldEncoder.php
@@ -51,5 +51,3 @@ final class RichTextFieldEncoder implements FieldEncoderInterface
         return new RichTextValue($decodedValue);
     }
 }
-
-class_alias(RichTextFieldEncoder::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\Field\RichTextFieldEncoder');

--- a/src/lib/Encoder/Field/TextLineFieldEncoder.php
+++ b/src/lib/Encoder/Field/TextLineFieldEncoder.php
@@ -42,5 +42,3 @@ final class TextLineFieldEncoder implements FieldEncoderInterface
         return new TextLineValue($value);
     }
 }
-
-class_alias(TextLineFieldEncoder::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\Field\TextLineFieldEncoder');

--- a/src/lib/Encoder/RichText/RichTextEncoder.php
+++ b/src/lib/Encoder/RichText/RichTextEncoder.php
@@ -208,5 +208,3 @@ final class RichTextEncoder
         );
     }
 }
-
-class_alias(RichTextEncoder::class, 'EzSystems\EzPlatformAutomatedTranslation\Encoder\RichText\RichTextEncoder');

--- a/src/lib/Exception/ClientNotConfiguredException.php
+++ b/src/lib/Exception/ClientNotConfiguredException.php
@@ -13,5 +13,3 @@ use RuntimeException;
 class ClientNotConfiguredException extends RuntimeException
 {
 }
-
-class_alias(ClientNotConfiguredException::class, 'EzSystems\EzPlatformAutomatedTranslation\Exception\ClientNotConfiguredException');

--- a/src/lib/Exception/EmptyTranslatedAttributeException.php
+++ b/src/lib/Exception/EmptyTranslatedAttributeException.php
@@ -13,5 +13,3 @@ use InvalidArgumentException;
 class EmptyTranslatedAttributeException extends InvalidArgumentException
 {
 }
-
-class_alias(EmptyTranslatedAttributeException::class, 'EzSystems\EzPlatformAutomatedTranslation\Exception\EmptyTranslatedAttributeException');

--- a/src/lib/Exception/EmptyTranslatedFieldException.php
+++ b/src/lib/Exception/EmptyTranslatedFieldException.php
@@ -13,5 +13,3 @@ use InvalidArgumentException;
 class EmptyTranslatedFieldException extends InvalidArgumentException
 {
 }
-
-class_alias(EmptyTranslatedFieldException::class, 'EzSystems\EzPlatformAutomatedTranslation\Exception\EmptyTranslatedFieldException');

--- a/src/lib/Exception/InvalidLanguageCodeException.php
+++ b/src/lib/Exception/InvalidLanguageCodeException.php
@@ -17,5 +17,3 @@ class InvalidLanguageCodeException extends InvalidArgumentException
         parent::__construct("$languageCode not recognized by $driver");
     }
 }
-
-class_alias(InvalidLanguageCodeException::class, 'EzSystems\EzPlatformAutomatedTranslation\Exception\InvalidLanguageCodeException');

--- a/src/lib/Translator.php
+++ b/src/lib/Translator.php
@@ -90,5 +90,3 @@ class Translator
         return $this->contentService->updateContent($contentDraft->versionInfo, $contentUpdateStruct);
     }
 }
-
-class_alias(Translator::class, 'EzSystems\EzPlatformAutomatedTranslation\Translator');

--- a/src/lib/TranslatorGuard.php
+++ b/src/lib/TranslatorGuard.php
@@ -77,5 +77,3 @@ class TranslatorGuard
         return $this->contentService->loadContentByContentInfo($content->contentInfo, [$languageCode]);
     }
 }
-
-class_alias(TranslatorGuard::class, 'EzSystems\EzPlatformAutomatedTranslation\TranslatorGuard');

--- a/tests/bundle/DependencyInjection/IbexaAutomatedTranslationExtensionTest.php
+++ b/tests/bundle/DependencyInjection/IbexaAutomatedTranslationExtensionTest.php
@@ -92,5 +92,3 @@ class IbexaAutomatedTranslationExtensionTest extends TestCase
         $this->assertEquals($expected, $hasConfiguredClientsResult);
     }
 }
-
-class_alias(IbexaAutomatedTranslationExtensionTest::class, 'EzSystems\EzPlatformAutomatedTranslationBundle\Tests\DependencyInjection\EzPlatformAutomatedTranslationExtensionTest');

--- a/tests/lib/Encoder/Field/RichTextFieldEncoderTest.php
+++ b/tests/lib/Encoder/Field/RichTextFieldEncoderTest.php
@@ -75,5 +75,3 @@ class RichTextFieldEncoderTest extends TestCase
         return (string) file_get_contents(__DIR__ . '/../../../fixtures/' . $name);
     }
 }
-
-class_alias(RichTextFieldEncoderTest::class, 'EzSystems\EzPlatformAutomatedTranslation\Tests\Encoder\Field\RichTextFieldEncoderTest');

--- a/tests/lib/Encoder/Field/TextLineFieldEncoderTest.php
+++ b/tests/lib/Encoder/Field/TextLineFieldEncoderTest.php
@@ -42,5 +42,3 @@ class TextLineFieldEncoderTest extends TestCase
         $this->assertEquals(new TextLine\Value('Some text 1'), $result);
     }
 }
-
-class_alias(TextLineFieldEncoderTest::class, 'EzSystems\EzPlatformAutomatedTranslation\Tests\Encoder\Field\TextLineFieldEncoderTest');

--- a/tests/lib/Encoder/RichText/RichTextEncoderTest.php
+++ b/tests/lib/Encoder/RichText/RichTextEncoderTest.php
@@ -95,5 +95,3 @@ class RichTextEncoderTest extends TestCase
         return (string) file_get_contents(__DIR__ . '/../../../fixtures/' . $name);
     }
 }
-
-class_alias(RichTextEncoderTest::class, 'EzSystems\EzPlatformAutomatedTranslation\Tests\Encoder\RichText\RichTextEncoderTest');

--- a/tests/lib/EncoderTest.php
+++ b/tests/lib/EncoderTest.php
@@ -148,5 +148,3 @@ XML;
         return (string) file_get_contents(__DIR__ . '/../fixtures/' . $name);
     }
 }
-
-class_alias(EncoderTest::class, 'EzSystems\EzPlatformAutomatedTranslation\Tests\EncoderTest');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

Additionally:
* Disabled php-http/discovery plugin
* Added necessary dev dependencies and sorted packages


#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
