### PR TITLE
Add Japanese to list of supported languages for DeepL

### DIFF
--- a/src/lib/Client/Deepl.php
+++ b/src/lib/Client/Deepl.php
@@ -88,5 +88,5 @@ class Deepl implements ClientInterface
     /**
      * List of available code https://www.deepl.com/api.html.
      */
-    private const LANGUAGE_CODES = ['EN', 'DE', 'FR', 'ES', 'IT', 'NL', 'PL','JP'];
+    private const LANGUAGE_CODES = ['EN', 'DE', 'FR', 'ES', 'IT', 'NL', 'PL', 'JA'];
 }

--- a/src/lib/Client/Deepl.php
+++ b/src/lib/Client/Deepl.php
@@ -88,5 +88,5 @@ class Deepl implements ClientInterface
     /**
      * List of available code https://www.deepl.com/api.html.
      */
-    private const LANGUAGE_CODES = ['EN', 'DE', 'FR', 'ES', 'IT', 'NL', 'PL'];
+    private const LANGUAGE_CODES = ['EN', 'DE', 'FR', 'ES', 'IT', 'NL', 'PL','JP'];
 }

--- a/src/lib/Client/Deepl.php
+++ b/src/lib/Client/Deepl.php
@@ -59,7 +59,7 @@ class Deepl implements ClientInterface
                 'timeout' => 5.0,
             ]
         );
-        $response = $http->post('/v1/translate', ['form_params' => $parameters]);
+        $response = $http->post('/v2/translate', ['form_params' => $parameters]);
         // May use the native json method from guzzle
         $json = json_decode($response->getBody()->getContents());
 


### PR DESCRIPTION
Not sure if this list is from an earlier time, but Japanese is supported by DeepL and this adds it to the constants.

Maybe this list should be either dynamically updated or moved to a configuration?