### PR TITLE
Add eztext support

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -9,6 +9,8 @@ services:
             tags: [ ibexa.automated_translation.field_encoder ]
 
     # field encoder
+    Ibexa\AutomatedTranslation\Encoder\Field\TextBlockFieldEncoder: ~
+
     Ibexa\AutomatedTranslation\Encoder\Field\TextLineFieldEncoder: ~
 
     Ibexa\AutomatedTranslation\Encoder\Field\RichTextFieldEncoder:

--- a/src/lib/Encoder/Field/TextBlockFieldEncoder.php
+++ b/src/lib/Encoder/Field/TextBlockFieldEncoder.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AutomatedTranslation\Encoder\Field;
+
+use Ibexa\AutomatedTranslation\Exception\EmptyTranslatedFieldException;
+use Ibexa\Contracts\AutomatedTranslation\Encoder\Field\FieldEncoderInterface;
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Core\FieldType\TextBlock\Value as TextBlockValue;
+use Ibexa\Core\FieldType\Value;
+
+final class TextBlockFieldEncoder implements FieldEncoderInterface
+{
+    public function canEncode(Field $field): bool
+    {
+        return $field->value instanceof TextBlockValue;
+    }
+
+    public function canDecode(string $type): bool
+    {
+        return TextBlockValue::class === $type;
+    }
+
+    public function encode(Field $field): string
+    {
+        return (string) $field->value;
+    }
+
+    public function decode(string $value, $previousFieldValue): Value
+    {
+        $value = trim($value);
+
+        if (strlen($value) === 0) {
+            throw new EmptyTranslatedFieldException();
+        }
+
+        return new TextBlockValue($value);
+    }
+}

--- a/tests/lib/Encoder/Field/TextBlockFieldEncoderTest.php
+++ b/tests/lib/Encoder/Field/TextBlockFieldEncoderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AutomatedTranslation\Encoder\Field;
+
+use Ibexa\AutomatedTranslation\Encoder\Field\TextBlockFieldEncoder;
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Core\FieldType\TextBlock;
+use PHPUnit\Framework\TestCase;
+
+class TextBlockFieldEncoderTest extends TestCase
+{
+    private const TEXT_BLOCK_VALUE = "Some text.\nSome more text.";
+
+    public function testEncode(): void
+    {
+        $field = new Field([
+            'fieldDefIdentifier' => 'field_1_TextBlock',
+            'value' => new TextBlock\Value(self::TEXT_BLOCK_VALUE),
+        ]);
+
+        $subject = new TextBlockFieldEncoder();
+        $result = $subject->encode($field);
+
+        $this->assertEquals(self::TEXT_BLOCK_VALUE, $result);
+    }
+
+    public function testDecode(): void
+    {
+        $field = new Field([
+            'fieldDefIdentifier' => 'field_1_TextBlock',
+            'value' => new TextBlock\Value(self::TEXT_BLOCK_VALUE),
+        ]);
+
+        $subject = new TextBlockFieldEncoder();
+        $result = $subject->decode(self::TEXT_BLOCK_VALUE, $field->value);
+
+        $this->assertInstanceOf(TextBlock\Value::class, $result);
+        $this->assertEquals(new TextBlock\Value(self::TEXT_BLOCK_VALUE), $result);
+    }
+}

--- a/tests/lib/Encoder/Field/TextBlockFieldEncoderTest.php
+++ b/tests/lib/Encoder/Field/TextBlockFieldEncoderTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Core\FieldType\TextBlock;
 use PHPUnit\Framework\TestCase;
 
-class TextBlockFieldEncoderTest extends TestCase
+final class TextBlockFieldEncoderTest extends TestCase
 {
     private const TEXT_BLOCK_VALUE = "Some text.\nSome more text.";
 


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-9157

The following Field Types / Page Builder Attributes are covered by the Automated Translation Bundle:

Field Type `ezstring`
Field Type `ezrichtext`
Page Builder attribute `text`
Page Builder attribute `richtext`

PR adds `eztext` support


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
