### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -1,0 +1,15 @@
+name: Rector PHP
+on:
+    push:
+        branches:
+            - main
+            - '[0-9]+.[0-9]+'
+    pull_request: ~
+jobs:
+    rector:
+        name: Run rector
+        uses: ibexa/gh-workflows/.github/workflows/rector.yml@main
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -32,16 +32,16 @@
     "require": {
         "php": "^8.3",
         "ext-libxml": "*",
-        "symfony/yaml": "^5.0",
-        "symfony/routing": "^5.0",
-        "symfony/console": "^5.0",
-        "symfony/form": "^5.0",
-        "symfony/http-foundation": "^5.0",
-        "symfony/event-dispatcher": "^5.0",
         "guzzlehttp/guzzle": "^6.3.0",
+        "ibexa/admin-ui": "~5.0.0@dev",
         "ibexa/core": "~5.0.0@dev",
         "ibexa/fieldtype-richtext": "~5.0.0@dev",
-        "ibexa/admin-ui": "~5.0.0@dev"
+        "symfony/console": "^6.4",
+        "symfony/event-dispatcher": "^6.4",
+        "symfony/form": "^6.4",
+        "symfony/http-foundation": "^6.4",
+        "symfony/routing": "^6.4",
+        "symfony/yaml": "^6.4"
     },
     "require-dev": {
         "dg/bypass-finals": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "ibexa/http-cache": "~5.0.x-dev",
         "ibexa/migrations": "~5.0.x-dev",
         "ibexa/notifications": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "ibexa/rest": "~5.0.x-dev",
         "ibexa/search": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Factory\IbexaRectorConfigFactory;
+
+return (new IbexaRectorConfigFactory(
+    [
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]
+))->createConfig();

--- a/src/bundle/Command/TranslateContentCommand.php
+++ b/src/bundle/Command/TranslateContentCommand.php
@@ -13,12 +13,14 @@ use Ibexa\AutomatedTranslation\Translator;
 use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\UserService;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'ibexa:automated:translate', description: 'Translate a Content in a new Language', aliases: ['ibexatranslate'])]
 final class TranslateContentCommand extends Command
 {
     private const ADMINISTRATOR_USER_ID = 14;
@@ -52,9 +54,6 @@ final class TranslateContentCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('ibexa:automated:translate')
-            ->setAliases(['ibexatranslate'])
-            ->setDescription('Translate a Content in a new Language')
             ->addArgument('contentId', InputArgument::REQUIRED, 'ContentId')
             ->addArgument(
                 'service',


### PR DESCRIPTION
| :ticket: Issue | IBX-8470 |
|----------------|-----------|

#### Related PRs:
- [x] https://github.com/ibexa/rector/pull/27

#### Description:

This PR bumps Symfony to v6 with necessary codebase upgrades.

Additionally we've decided to add Rector PHP CI workflow to protect against accidental introduction of obsolete or deprecated code.

Key changes:

- [x] [Composer] Bumped Symfony packages requirements to ^6.4
- [x] IBX-9627: [GHA] Configured Rector PHP workflow
- [x] [Rector] Upgraded codebase according to configured rules

#### QA:

Package sanity tests or regression tests, if available.

#### Documentation:

No documentation required.
