### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, Closure\(mixed\)\: \(array\|null\) given\.$#'
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, Closure\(array\)\: \(array\|null\) given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php

--- a/src/bundle/Controller/TranslationController.php
+++ b/src/bundle/Controller/TranslationController.php
@@ -16,8 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class TranslationController extends Controller
 {
-    /** @var \Ibexa\Bundle\AdminUi\Controller\TranslationController */
-    private $translationController;
+    private BaseTranslationController $translationController;
 
     public function __construct(BaseTranslationController $translationController)
     {

--- a/src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php
+++ b/src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php
@@ -60,8 +60,8 @@ class IbexaAutomatedTranslationExtension extends Extension implements PrependExt
      */
     private function hasConfiguredClients(array $config, ContainerBuilder $container): bool
     {
-        return 0 !== count(array_filter($config['system'], static function ($value) use ($container) {
-            return array_filter($value['configurations'], static function ($value) use ($container) {
+        return 0 !== count(array_filter($config['system'], static function (array $value) use ($container): ?array {
+            return array_filter($value['configurations'], static function ($value) use ($container): bool {
                 $value = is_array($value) ? reset($value) : $value;
 
                 return !empty($container->resolveEnvPlaceholders($value, true));

--- a/src/bundle/Event/FieldDecodeEvent.php
+++ b/src/bundle/Event/FieldDecodeEvent.php
@@ -12,11 +12,9 @@ use Ibexa\Core\FieldType\Value;
 
 final class FieldDecodeEvent
 {
-    /** @var string */
-    private $type;
+    private string $type;
 
-    /** @var \Ibexa\Core\FieldType\Value */
-    private $value;
+    private Value $value;
 
     /** @var mixed */
     private $previousValue;

--- a/src/bundle/Event/FieldEncodeEvent.php
+++ b/src/bundle/Event/FieldEncodeEvent.php
@@ -12,11 +12,9 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 
 final class FieldEncodeEvent
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Field */
-    private $field;
+    private Field $field;
 
-    /** @var string */
-    private $value;
+    private string $value;
 
     public function __construct(
         Field $field,

--- a/src/bundle/Form/Extension/ContentEditType.php
+++ b/src/bundle/Form/Extension/ContentEditType.php
@@ -21,14 +21,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class ContentEditType extends AbstractTypeExtension
 {
-    /** @var \Ibexa\AutomatedTranslation\Translator */
-    private $translator;
+    private Translator $translator;
 
-    /** @var \Symfony\Component\HttpFoundation\RequestStack */
-    private $requestStack;
+    private RequestStack $requestStack;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(
         Translator $translator,
@@ -49,7 +46,7 @@ class ContentEditType extends AbstractTypeExtension
     {
         $builder->addEventListener(
             FormEvents::PRE_SET_DATA,
-            function (FormEvent $event) {
+            function (FormEvent $event): void {
                 /** @var \Ibexa\AdminUi\Form\Data\ContentTranslationData $data */
                 $data = $event->getData();
                 if (!$data instanceof ContentTranslationData) {

--- a/src/bundle/Form/Extension/TranslationAddType.php
+++ b/src/bundle/Form/Extension/TranslationAddType.php
@@ -23,11 +23,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TranslationAddType extends AbstractTypeExtension
 {
-    /** @var \Ibexa\AutomatedTranslation\ClientProvider */
-    private $clientProvider;
+    private ClientProvider $clientProvider;
 
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\LocaleConverterInterface */
-    private $localeConverter;
+    private LocaleConverterInterface $localeConverter;
 
     public function __construct(
         ClientProvider $clientProvider,
@@ -86,7 +84,7 @@ class TranslationAddType extends AbstractTypeExtension
 
                         return $client;
                     },
-                    'choice_value' => static function ($client) {
+                    'choice_value' => static function ($client): string {
                         if ($client instanceof ClientInterface) {
                             return $client->getServiceAlias();
                         }
@@ -104,7 +102,7 @@ class TranslationAddType extends AbstractTypeExtension
         // let's pass to the template/form the possible language
         $map = [];
 
-        $fillMap = function ($key, &$map) use ($form) {
+        $fillMap = function ($key, array &$map) use ($form): void {
             $languages = $form->get($key);
             $choices = $languages->getConfig()->getAttribute('choice_list')->getChoices();
             /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Language $language */

--- a/src/lib/Encoder/BlockAttribute/BlockAttributeEncoderManager.php
+++ b/src/lib/Encoder/BlockAttribute/BlockAttributeEncoderManager.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
 class BlockAttributeEncoderManager
 {
     /** @var iterable|\Ibexa\Contracts\AutomatedTranslation\Encoder\BlockAttribute\BlockAttributeEncoderInterface[] */
-    private $blockAttributeEncoders;
+    private iterable $blockAttributeEncoders;
 
     /**
      * @param iterable|\Ibexa\Contracts\AutomatedTranslation\Encoder\BlockAttribute\BlockAttributeEncoderInterface[] $blockAttributeEncoders

--- a/src/lib/Encoder/Field/FieldEncoderManager.php
+++ b/src/lib/Encoder/Field/FieldEncoderManager.php
@@ -15,7 +15,7 @@ use InvalidArgumentException;
 final class FieldEncoderManager
 {
     /** @var iterable|\Ibexa\Contracts\AutomatedTranslation\Encoder\Field\FieldEncoderInterface[] */
-    private $fieldEncoders;
+    private iterable $fieldEncoders;
 
     /**
      * @param iterable|\Ibexa\Contracts\AutomatedTranslation\Encoder\Field\FieldEncoderInterface[] $fieldEncoders

--- a/src/lib/Encoder/RichText/RichTextEncoder.php
+++ b/src/lib/Encoder/RichText/RichTextEncoder.php
@@ -97,7 +97,7 @@ final class RichTextEncoder
         foreach ($this->nonTranslatableSelfClosingTags as $tag) {
             $xmlString = (string) preg_replace_callback(
                 '#<' . $tag . '(.[^>]*)?/>#Uuim',
-                function ($matches) use ($tag) {
+                function ($matches) use ($tag): string {
                     $hash = $this->hash($matches[0]);
                     $this->placeHolderMap[$hash] = $matches[0];
 
@@ -110,7 +110,7 @@ final class RichTextEncoder
         foreach ($this->nonTranslatableTags as $tag) {
             $xmlString = (string) preg_replace_callback(
                 '#<' . $tag . '(>| (.[^>]*)?>)((?:.|\n)*)</' . $tag . '>#Uuim',
-                function ($matches) use ($tag) {
+                function ($matches) use ($tag): string {
                     $hash = $this->hash($matches[0]);
                     $this->placeHolderMap[$hash] = $matches[0];
 
@@ -123,7 +123,7 @@ final class RichTextEncoder
         foreach ($this->nonValidAttributeTags as $tag) {
             $xmlString = (string) preg_replace_callback(
                 '#<' . $tag . '(.[^>]*)>#Uuim',
-                function ($matches) use ($tag) {
+                function ($matches) use ($tag): string {
                     $hash = $this->hash($matches[0]);
                     $this->placeHolderMap[$hash] = $matches[0];
 
@@ -154,7 +154,7 @@ final class RichTextEncoder
         foreach (array_reverse($this->nonTranslatableSelfClosingTags) as $tag) {
             $value = (string) preg_replace_callback(
                 '#<' . $tag . '>(.*)</' . $tag . '>#Uuim',
-                function ($matches) {
+                function (array $matches) {
                     return $this->placeHolderMap[trim($matches[1])];
                 },
                 $value
@@ -164,7 +164,7 @@ final class RichTextEncoder
         foreach (array_reverse($this->nonTranslatableTags) as $tag) {
             $value = (string) preg_replace_callback(
                 '#<' . $tag . '>(.*)</' . $tag . '>#Uuim',
-                function ($matches) {
+                function (array $matches) {
                     return $this->placeHolderMap[trim($matches[1])];
                 },
                 $value
@@ -174,7 +174,7 @@ final class RichTextEncoder
         foreach ($this->nonValidAttributeTags as $tag) {
             $value = (string) preg_replace_callback(
                 '#<fake' . $tag . '(.[^>]*)>#Uuim',
-                function ($matches) {
+                function (array $matches) {
                     return $this->placeHolderMap[trim(str_replace('="1"', '', $matches[1]))];
                 },
                 $value

--- a/tests/lib/Encoder/RichText/RichTextEncoderTest.php
+++ b/tests/lib/Encoder/RichText/RichTextEncoderTest.php
@@ -15,8 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class RichTextEncoderTest extends TestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private MockObject $configResolver;
+    private ConfigResolverInterface&MockObject $configResolver;
 
     public function setUp(): void
     {

--- a/tests/lib/Encoder/RichText/RichTextEncoderTest.php
+++ b/tests/lib/Encoder/RichText/RichTextEncoderTest.php
@@ -10,12 +10,13 @@ namespace Ibexa\Tests\AutomatedTranslation\Encoder\RichText;
 
 use Ibexa\AutomatedTranslation\Encoder\RichText\RichTextEncoder;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RichTextEncoderTest extends TestCase
 {
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private MockObject $configResolver;
 
     public function setUp(): void
     {

--- a/tests/lib/EncoderTest.php
+++ b/tests/lib/EncoderTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\AutomatedTranslation;
 
 use Ibexa\AutomatedTranslation\Encoder;
 use Ibexa\AutomatedTranslation\Encoder\Field\FieldEncoderManager;
+use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
@@ -134,13 +135,11 @@ XML;
 
     /**
      * Returns ContentTypeService mock object.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getContentTypeServiceMock(): MockObject
+    protected function getContentTypeServiceMock(): ContentTypeService&MockObject
     {
         return $this
-            ->getMockBuilder('Ibexa\\Contracts\\Core\\Repository\\ContentTypeService')
+            ->getMockBuilder(ContentTypeService::class)
             ->getMock();
     }
 

--- a/tests/lib/EncoderTest.php
+++ b/tests/lib/EncoderTest.php
@@ -17,6 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\TextLine;
 use Ibexa\Core\Repository\Values\Content\Content;
 use Ibexa\Core\Repository\Values\Content\VersionInfo;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -136,7 +137,7 @@ XML;
      *
      * @return \Ibexa\Contracts\Core\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getContentTypeServiceMock()
+    protected function getContentTypeServiceMock(): MockObject
     {
         return $this
             ->getMockBuilder('Ibexa\\Contracts\\Core\\Repository\\ContentTypeService')


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
