### PR TITLE
Bumped guzzle to 7.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^8.3",
         "ext-libxml": "*",
-        "guzzlehttp/guzzle": "^6.3.0",
+        "guzzlehttp/guzzle": "^7.9",
         "ibexa/admin-ui": "~5.0.0@dev",
         "ibexa/core": "~5.0.0@dev",
         "ibexa/fieldtype-richtext": "~5.0.0@dev",


### PR DESCRIPTION
Bumped Guzzle so that the version used is uniform across all packages.

Right now the error is:
```
     - Root composer.json requires ibexa/automated-translation 5.0.x-dev -> satisfiable by ibexa/automated-translation[5.0.x-dev (alias of dev-main)].
    - Root composer.json requires ibexa/personalization 5.0.x-dev -> satisfiable by ibexa/personalization[5.0.x-dev (alias of dev-main)].
    - ibexa/automated-translation dev-main requires guzzlehttp/guzzle ^6.3.0 -> satisfiable by guzzlehttp/guzzle[6.3.0, ..., 6.5.8].
    - ibexa/personalization dev-main requires guzzlehttp/guzzle ^7.9 -> satisfiable by guzzlehttp/guzzle[7.9.0, 7.9.1, 7.9.2, 7.9.3].
    - You can only install one version of a package, so only one of these can be installed: guzzlehttp/guzzle[6.0.0, ..., 6.5.8, 7.0.0, ..., 7.9.3].
    - ibexa/automated-translation 5.0.x-dev is an alias of ibexa/automated-translation dev-main and thus requires it to be installed too.
    - ibexa/personalization 5.0.x-dev is an alias of ibexa/personalization dev-main and thus requires it to be installed too.
```

### QA:

Yes, please 🙈 