### PR TITLE
IBX-9968: Resolved Symfony 7.x deprecations

### DIFF
--- a/src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php
+++ b/src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php
@@ -13,9 +13,9 @@ use Ibexa\Contracts\AutomatedTranslation\Encoder\BlockAttribute\BlockAttributeEn
 use Ibexa\Contracts\AutomatedTranslation\Encoder\Field\FieldEncoderInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class IbexaAutomatedTranslationExtension extends Extension implements PrependExtensionInterface
 {

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -36,14 +36,14 @@ services:
     Ibexa\AutomatedTranslation\Client\:
         resource: '../../../lib/Client'
         tags: [ ibexa.automated_translation.client ]
-    
+
     Ibexa\AutomatedTranslation\Client\Deepl:
         arguments:
             $languageMap: '%ibexa.automated_translation.deepl.language_map%'
         tags: [ ibexa.automated_translation.client ]
 
     Ibexa\AutomatedTranslation\ClientProvider:
-        arguments: [!tagged ibexa.automated_translation.client]
+        arguments: [!tagged_iterator ibexa.automated_translation.client]
 
     Ibexa\Bundle\AutomatedTranslation\Command\TranslateContentCommand: ~
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9968  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled Rector Symfony 7.0, 7.1 and 7.2 sets. Resolved the following deprecations:

```
* [symfony/http-kernel] Replaced usage of internal Symfony\Component\HttpKernel\DependencyInjection\Extension class
* [symfony/dependency-injection] Replaced deprecated !tagged YAML tag to !tagged_iterator 
```

#### For QA:

Sanities.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
