### PR TITLE
Moved `ClientNotConfiguredException` to contracts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, Closure\(array\)\: \(array\|null\) given\.$#'
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, Closure\(array\)\: array given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php

--- a/src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php
+++ b/src/bundle/DependencyInjection/IbexaAutomatedTranslationExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 
-class IbexaAutomatedTranslationExtension extends Extension implements PrependExtensionInterface
+final class IbexaAutomatedTranslationExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -60,7 +60,7 @@ class IbexaAutomatedTranslationExtension extends Extension implements PrependExt
      */
     private function hasConfiguredClients(array $config, ContainerBuilder $container): bool
     {
-        return 0 !== count(array_filter($config['system'], static function (array $value) use ($container): ?array {
+        return 0 !== count(array_filter($config['system'], static function (array $value) use ($container): array {
             return array_filter($value['configurations'], static function ($value) use ($container): bool {
                 $value = is_array($value) ? reset($value) : $value;
 

--- a/src/contracts/Exception/ClientNotConfiguredException.php
+++ b/src/contracts/Exception/ClientNotConfiguredException.php
@@ -6,10 +6,10 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\AutomatedTranslation\Exception;
+namespace Ibexa\Contracts\AutomatedTranslation\Exception;
 
 use RuntimeException;
 
-class ClientNotConfiguredException extends RuntimeException
+final class ClientNotConfiguredException extends RuntimeException
 {
 }

--- a/src/lib/Client/Deepl.php
+++ b/src/lib/Client/Deepl.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace Ibexa\AutomatedTranslation\Client;
 
 use GuzzleHttp\Client;
-use Ibexa\AutomatedTranslation\Exception\ClientNotConfiguredException;
 use Ibexa\AutomatedTranslation\Exception\InvalidLanguageCodeException;
 use Ibexa\Contracts\AutomatedTranslation\Client\ClientInterface;
+use Ibexa\Contracts\AutomatedTranslation\Exception\ClientNotConfiguredException;
 
 class Deepl implements ClientInterface
 {

--- a/src/lib/Client/Google.php
+++ b/src/lib/Client/Google.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace Ibexa\AutomatedTranslation\Client;
 
 use GuzzleHttp\Client;
-use Ibexa\AutomatedTranslation\Exception\ClientNotConfiguredException;
 use Ibexa\AutomatedTranslation\Exception\InvalidLanguageCodeException;
 use Ibexa\Contracts\AutomatedTranslation\Client\ClientInterface;
+use Ibexa\Contracts\AutomatedTranslation\Exception\ClientNotConfiguredException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 


### PR DESCRIPTION
| :ticket: Issue | - |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This seems to be a low-hanging fruit - it will resolve Deptrac issue reported in this example:
https://doc.ibexa.co/en/latest/multisite/languages/automated_translations/#add-a-custom-machine-translation-service
https://github.com/ibexa/documentation-developer/blob/add-deptrac/deptrac.baseline.yaml#L23-L24

Since it targets `main` I would say it shouldn't be harmful.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
