### PR TITLE
IBX-11689: automated translations does not work with free version of deepL

### DIFF
--- a/src/lib/Client/Deepl.php
+++ b/src/lib/Client/Deepl.php
@@ -26,6 +26,8 @@ class Deepl implements ClientInterface
 
     private string $authKey;
 
+    private bool $apiFree = false;
+
     /** @var array<string, string> */
     private array $languageMap;
 
@@ -56,6 +58,14 @@ class Deepl implements ClientInterface
             throw new ClientNotConfiguredException('authKey is required');
         }
         $this->authKey = $configuration['authKey'];
+
+        if (array_key_exists('apiFree', $configuration)) {
+            $this->apiFree = filter_var(
+                $configuration['apiFree'],
+                FILTER_VALIDATE_BOOLEAN,
+                FILTER_NULL_ON_FAILURE
+            ) ?? false;
+        }
     }
 
     public function translate(string $payload, ?string $from, string $to): string
@@ -72,9 +82,13 @@ class Deepl implements ClientInterface
             ];
         }
 
+        $baseUri = $this->apiFree
+            ? 'https://api-free.deepl.com'
+            : 'https://api.deepl.com';
+
         $http = new Client(
             [
-                'base_uri' => 'https://api.deepl.com',
+                'base_uri' => $baseUri,
                 'timeout' => 5.0,
                 'headers' => [
                     'Authorization' => 'DeepL-Auth-Key ' . $this->authKey,


### PR DESCRIPTION
| :ticket: Issue | IBX-11689 |
|----------------|-----------|

#### Description:
Adds support for free version of DeepL


#### For QA:
 - Create deepl token with free account
 - try to translate content

#### Documentation:
This page needs to be updated: https://doc.ibexa.co/en/4.6/multisite/languages/automated_translations/#configure-access-to-translation-services

Example : 
```
                deepl:
                    authKey: "deepl-free-key"
                    apiFree: true
```


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
