### PR TITLE
IBX-11802: Automated translations with Page builder blocks with ezstring and eztext that contains special characters fails

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -45,5 +45,5 @@ parameters:
 		-
 			message: '#^Return type of call to method PHPUnit\\Framework\\MockObject\\MockBuilder\<Ibexa\\AutomatedTranslation\\Encoder\\Field\\FieldEncoderManager\>\:\:getMock\(\) contains unresolvable type\.$#'
 			identifier: method.unresolvableReturnType
-			count: 2
+			count: 3
 			path: tests/lib/EncoderTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -39,7 +39,7 @@ parameters:
 		-
 			message: '#^Return type of call to method PHPUnit\\Framework\\MockObject\\MockBuilder\<Ibexa\\AutomatedTranslation\\Encoder\\RichText\\RichTextEncoder\>\:\:getMock\(\) contains unresolvable type\.$#'
 			identifier: method.unresolvableReturnType
-			count: 2
+			count: 3
 			path: tests/lib/Encoder/Field/RichTextFieldEncoderTest.php
 
 		-

--- a/src/lib/Encoder.php
+++ b/src/lib/Encoder.php
@@ -45,7 +45,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  *      <response>
  *             <title>The string value</title>
  *             <description>
- *                  <![CDATA[<?xml version="1.0" encoding="UTF-8"?><section><para>lorem ipsum</para></section>]]>
+ *                  <![CDATA[<section><para>lorem ipsum</para></section>]]>
  *              </description>
  *      </response>
  *
@@ -70,8 +70,6 @@ class Encoder
      * Use to fake the <![CDATA[ something ]]> to <fakecdata> something </fakecdata>.
      */
     private const CDATA_FAKER_TAG = 'fakecdata';
-
-    private const XML_MARKUP = '<?xml version="1.0" encoding="UTF-8"?>';
 
     private ContentTypeService $contentTypeService;
 
@@ -140,7 +138,7 @@ class Encoder
         $encoder = new XmlEncoder();
         $data = str_replace(
             ['<' . self::CDATA_FAKER_TAG . '>', '</' . self::CDATA_FAKER_TAG . '>'],
-            ['<![CDATA[' . self::XML_MARKUP, ']]>'],
+            ['<![CDATA[', ']]>'],
             $xml
         );
 

--- a/src/lib/Encoder/Field/RichTextFieldEncoder.php
+++ b/src/lib/Encoder/Field/RichTextFieldEncoder.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AutomatedTranslation\Encoder\Field;
 
+use DOMDocument;
 use Ibexa\AutomatedTranslation\Encoder\RichText\RichTextEncoder;
 use Ibexa\AutomatedTranslation\Exception\EmptyTranslatedFieldException;
 use Ibexa\Contracts\AutomatedTranslation\Encoder\Field\FieldEncoderInterface;
@@ -48,7 +49,12 @@ final class RichTextFieldEncoder implements FieldEncoderInterface
             throw new EmptyTranslatedFieldException();
         }
 
-        return new RichTextValue($decodedValue);
+        $document = new DOMDocument();
+        $document->loadXML($decodedValue);
+        // encoding has to be set after loadXML(), which resets it
+        $document->encoding = 'UTF-8';
+
+        return new RichTextValue($document);
     }
 }
 

--- a/src/lib/Encoder/RichText/RichTextEncoder.php
+++ b/src/lib/Encoder/RichText/RichTextEncoder.php
@@ -14,7 +14,8 @@ final class RichTextEncoder
 {
     private const CDATA_FAKER_TAG = 'fake_rt_cdata';
 
-    private const XML_MARKUP = '<?xml version="1.0" encoding="UTF-8"?>';
+    // a literal is not enough: DOMDocument omits the encoding when the source had none
+    private const XML_DECLARATION_REGEXP = '/^<\?xml\b[^?]*\?>\s*/';
 
     /**
      * Allow to replace characters preserve eZ RichText Content.
@@ -88,9 +89,7 @@ final class RichTextEncoder
 
     public function encode(string $xmlString): string
     {
-        if (strpos($xmlString, self::XML_MARKUP . "\n") !== false) {
-            $xmlString = substr($xmlString, strlen(self::XML_MARKUP . "\n"));
-        }
+        $xmlString = (string) preg_replace(self::XML_DECLARATION_REGEXP, '', $xmlString);
 
         $xmlString = $this->encodeNonTranslatableCharacters($xmlString);
 

--- a/src/lib/Exception/CdataCleanupFailedException.php
+++ b/src/lib/Exception/CdataCleanupFailedException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AutomatedTranslation\Exception;
+
+use RuntimeException;
+
+class CdataCleanupFailedException extends RuntimeException
+{
+}

--- a/src/lib/TextFieldCdataCleaner.php
+++ b/src/lib/TextFieldCdataCleaner.php
@@ -13,11 +13,20 @@ use DOMDocument;
 use DOMElement;
 use DOMNode;
 use DOMXPath;
+use Ibexa\AutomatedTranslation\Exception\CdataCleanupFailedException;
+use Ibexa\FieldTypePage\FieldType\LandingPage\Value as LandingPageValue;
 use Ibexa\FieldTypeRichText\FieldType\RichText\Value as RichTextValue;
-use RuntimeException;
+use LibXMLError;
 
 final class TextFieldCdataCleaner
 {
+    // field values are identified by class, Page Builder block attributes by their short type name
+    private const CDATA_PRESERVING_TYPES = [
+        RichTextValue::class,
+        LandingPageValue::class,
+        'richtext',
+    ];
+
     public function clear(string $payload): string
     {
         $dom = $this->loadDocument($payload);
@@ -29,9 +38,35 @@ final class TextFieldCdataCleaner
     private function loadDocument(string $payload): DOMDocument
     {
         $dom = new DOMDocument();
-        $dom->loadXML($payload);
+
+        $useInternalErrors = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        try {
+            if (!$dom->loadXML($payload)) {
+                throw new CdataCleanupFailedException(sprintf(
+                    'Unable to load XML payload while removing CDATA: %s',
+                    $this->getLibXmlErrorMessage()
+                ));
+            }
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($useInternalErrors);
+        }
 
         return $dom;
+    }
+
+    private function getLibXmlErrorMessage(): string
+    {
+        $messages = array_map(
+            static function (LibXMLError $error): string {
+                return trim($error->message);
+            },
+            libxml_get_errors()
+        );
+
+        return implode(', ', $messages);
     }
 
     private function processCdataNodes(DOMDocument $dom): void
@@ -61,7 +96,15 @@ final class TextFieldCdataCleaner
             return false;
         }
 
-        return $parent->getAttribute('type') !== RichTextValue::class;
+        $type = $parent->getAttribute('type');
+        foreach (self::CDATA_PRESERVING_TYPES as $preservedType) {
+            // is_a() because field values may be lazy loading proxies, whose class name is generated
+            if ($type === $preservedType || is_a($type, $preservedType, true)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function replaceWithTextNode(DOMDocument $dom, DOMCdataSection $cdataNode): void
@@ -78,7 +121,7 @@ final class TextFieldCdataCleaner
         $result = $dom->saveXML();
 
         if ($result === false) {
-            throw new RuntimeException('Saving XML failed after removing CDATA.');
+            throw new CdataCleanupFailedException('Saving XML failed after removing CDATA.');
         }
 
         return $result;

--- a/tests/lib/Encoder/Field/PageBuilderFieldEncoderTest.php
+++ b/tests/lib/Encoder/Field/PageBuilderFieldEncoderTest.php
@@ -20,12 +20,19 @@ use Ibexa\Contracts\FieldTypePage\FieldType\Page\Block\Definition\BlockAttribute
 use Ibexa\Contracts\FieldTypePage\FieldType\Page\Block\Definition\BlockDefinition;
 use Ibexa\FieldTypePage\FieldType\LandingPage\Value;
 use Ibexa\FieldTypePage\FieldType\Page\Block\Definition\BlockDefinitionFactoryInterface;
+use Ibexa\Tests\AutomatedTranslation\WellFormedXmlAssertionTrait;
 use PHPUnit\Framework\TestCase;
 
 final class PageBuilderFieldEncoderTest extends TestCase
 {
+    use WellFormedXmlAssertionTrait;
+
     public const ATTRIBUTE_VALUE = 'ibexa';
     public const ATTRIBUTE_VALUE_CDATA = 'ibexa & ibexa';
+
+    private const BLOCK_NAME_WITH_AMP = 'Code & Co';
+    private const TEXT_ATTRIBUTE_VALUE = 'Tom & Jerry <3 Café';
+    private const RICHTEXT_ATTRIBUTE_VALUE = '<section ATTR1="1"><para>Tom &amp; Jerry &lt;3 Café</para></section>';
 
     /** @var \Ibexa\AutomatedTranslation\Encoder\BlockAttribute\BlockAttributeEncoderManager&\PHPUnit\Framework\MockObject\MockObject */
     private BlockAttributeEncoderManager $blockAttributeEncoderManagerMock;
@@ -162,26 +169,121 @@ final class PageBuilderFieldEncoderTest extends TestCase
         self::assertTrue($subject->canDecode(get_class($field->value)));
     }
 
-    private function getLandingPageField(): Field
+    public function testEncodeRichTextAttributeKeepsCdataWrapper(): void
     {
+        $payload = $this->encodeBlockWith(self::RICHTEXT_ATTRIBUTE_VALUE, 'richtext');
+
+        self::assertStringContainsString('<fake_blocks_cdata>', $payload);
+        self::assertStringContainsString('<section', $payload);
+        self::assertStringNotContainsString('&lt;section', $payload);
+        $this->assertWellFormedXml($payload);
+    }
+
+    public function testEncodeDecodeRichTextAttributeWithSpecialCharacters(): void
+    {
+        $payload = $this->encodeBlockWith(self::RICHTEXT_ATTRIBUTE_VALUE, 'richtext');
+
+        $this->assertWellFormedXml($payload);
+
+        // escaping is symmetric: the decode assertions below pass with or without the wrapper
+        self::assertStringContainsString('<fake_blocks_cdata>', $payload);
+        self::assertStringNotContainsString('&lt;section', $payload);
+
+        $result = $this->decodeBlockPayload($payload, self::RICHTEXT_ATTRIBUTE_VALUE);
+        $page = $result->getPage();
+
+        self::assertNotNull($page);
+
+        $attribute = $page->getBlockById('1')->getAttribute('content');
+        self::assertNotNull($attribute);
+        self::assertSame(self::RICHTEXT_ATTRIBUTE_VALUE, $attribute->getValue());
+    }
+
+    public function testEncodeDecodeTextAttributeWithSpecialCharacters(): void
+    {
+        $payload = $this->encodeBlockWith(self::TEXT_ATTRIBUTE_VALUE, 'text');
+
+        self::assertStringNotContainsString('fake_blocks_cdata', $payload);
+        self::assertStringContainsString('Tom &amp; Jerry &lt;3', $payload);
+        $this->assertWellFormedXml($payload);
+
+        $result = $this->decodeBlockPayload($payload, self::TEXT_ATTRIBUTE_VALUE);
+        $page = $result->getPage();
+
+        self::assertNotNull($page);
+        self::assertSame(self::BLOCK_NAME_WITH_AMP, $page->getBlockById('1')->getName());
+
+        $attribute = $page->getBlockById('1')->getAttribute('content');
+        self::assertNotNull($attribute);
+        self::assertSame(self::TEXT_ATTRIBUTE_VALUE, $attribute->getValue());
+    }
+
+    private function encodeBlockWith(string $attributeValue, string $attributeType): string
+    {
+        $this->blockDefinitionFactoryMock
+            ->method('getBlockDefinition')
+            ->withAnyParameters()
+            ->willReturn($this->getBlockDefinition($attributeType));
+
+        $this->blockAttributeEncoderManagerMock
+            ->method('encode')
+            ->withAnyParameters()
+            ->willReturnArgument(1);
+
+        $subject = new PageBuilderFieldEncoder(
+            $this->blockAttributeEncoderManagerMock,
+            $this->blockDefinitionFactoryMock,
+            new TextFieldCdataCleaner()
+        );
+
+        return $subject->encode($this->getLandingPageField(self::BLOCK_NAME_WITH_AMP, $attributeValue));
+    }
+
+    private function decodeBlockPayload(string $payload, string $attributeValue): Value
+    {
+        $this->blockAttributeEncoderManagerMock
+            ->method('decode')
+            ->withAnyParameters()
+            ->willReturnArgument(1);
+
+        $subject = new PageBuilderFieldEncoder(
+            $this->blockAttributeEncoderManagerMock,
+            $this->blockDefinitionFactoryMock,
+            new TextFieldCdataCleaner()
+        );
+
+        $result = $subject->decode(
+            $payload,
+            $this->getLandingPageField(self::BLOCK_NAME_WITH_AMP, $attributeValue)->value
+        );
+
+        self::assertInstanceOf(Value::class, $result);
+
+        return $result;
+    }
+
+    private function getLandingPageField(
+        string $blockName = 'Code',
+        string $attributeValue = self::ATTRIBUTE_VALUE
+    ): Field {
         return new Field([
             'fieldDefIdentifier' => 'field_landing_page',
-            'value' => new Value($this->getPage()),
+            'value' => new Value($this->getPage($blockName, $attributeValue)),
         ]);
     }
 
-    private function getPage(): Page
+    private function getPage(string $blockName = 'Code', string $attributeValue = self::ATTRIBUTE_VALUE): Page
     {
-        return new Page('default', [$this->createZone()]);
+        return new Page('default', [$this->createZone($blockName, $attributeValue)]);
     }
 
-    private function createZone(): Zone
+    private function createZone(string $blockName = 'Code', string $attributeValue = self::ATTRIBUTE_VALUE): Zone
     {
         return new Zone('1', 'Foo', [
             new BlockValue(
                 '1',
                 'tag',
-                'Code',
+                $blockName,
                 'default',
                 null,
                 null,
@@ -192,14 +294,14 @@ final class PageBuilderFieldEncoderTest extends TestCase
                     new Attribute(
                         '1',
                         'content',
-                        self::ATTRIBUTE_VALUE
+                        $attributeValue
                     ),
                 ]
             ),
         ]);
     }
 
-    private function getBlockDefinition(): BlockDefinition
+    private function getBlockDefinition(string $attributeType = 'string'): BlockDefinition
     {
         $blockDefinition = $this->createBlockDefinition();
 
@@ -207,7 +309,7 @@ final class PageBuilderFieldEncoderTest extends TestCase
         $blockAttributeDefinition = new BlockAttributeDefinition();
         $blockAttributeDefinition->setIdentifier('1');
         $blockAttributeDefinition->setName('content');
-        $blockAttributeDefinition->setType('string');
+        $blockAttributeDefinition->setType($attributeType);
         $blockAttributeDefinition->setConstraints([]);
         $blockAttributeDefinition->setValue(self::ATTRIBUTE_VALUE);
         $blockAttributeDefinition->setCategory('default');

--- a/tests/lib/Encoder/Field/RichTextFieldEncoderTest.php
+++ b/tests/lib/Encoder/Field/RichTextFieldEncoderTest.php
@@ -70,6 +70,32 @@ class RichTextFieldEncoderTest extends TestCase
         $this->assertEquals(new RichText\Value($xml1), $result);
     }
 
+    public function testDecodeRestoresUtf8Encoding(): void
+    {
+        $decodedXml = '<section xmlns="http://docbook.org/ns/docbook" version="5.0-variant ezpublish-1.0">'
+            . '<para>Café &amp; crème — Привет</para></section>';
+
+        $richTextEncoderMock = $this->getMockBuilder(RichTextEncoder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $richTextEncoderMock
+            ->expects($this->atLeastOnce())
+            ->method('decode')
+            ->withAnyParameters()
+            ->willReturn($decodedXml);
+
+        $subject = new RichTextFieldEncoder($richTextEncoderMock);
+        $result = $subject->decode($decodedXml, new RichText\Value($decodedXml));
+
+        $storedXml = (string) $result;
+
+        self::assertStringContainsString('encoding="UTF-8"', $storedXml);
+        self::assertStringContainsString('Café', $storedXml);
+        self::assertStringContainsString('Привет', $storedXml);
+        self::assertStringNotContainsString('&#x', $storedXml);
+    }
+
     protected function getFixture(string $name): string
     {
         return (string) file_get_contents(__DIR__ . '/../../../fixtures/' . $name);

--- a/tests/lib/Encoder/RichText/RichTextEncoderTest.php
+++ b/tests/lib/Encoder/RichText/RichTextEncoderTest.php
@@ -90,6 +90,33 @@ class RichTextEncoderTest extends TestCase
         $this->assertEquals($xml1, $decodeResult);
     }
 
+    /**
+     * @dataProvider provideXmlDeclarations
+     */
+    public function testEncodeStripsXmlDeclarationVariants(string $declaration): void
+    {
+        $subject = new RichTextEncoder($this->configResolver);
+
+        $encodeResult = $subject->encode($declaration . '<section><para>lorem ipsum</para></section>');
+
+        self::assertStringNotContainsString('<?xml', $encodeResult);
+        self::assertStringStartsWith('<section>', $encodeResult);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public function provideXmlDeclarations(): iterable
+    {
+        yield 'with encoding and newline' => ['<?xml version="1.0" encoding="UTF-8"?>' . "\n"];
+        yield 'with encoding, no newline' => ['<?xml version="1.0" encoding="UTF-8"?>'];
+        yield 'without encoding' => ['<?xml version="1.0"?>' . "\n"];
+        yield 'single quoted' => ["<?xml version='1.0' encoding='UTF-8'?>\n"];
+        yield 'windows line ending' => ['<?xml version="1.0" encoding="UTF-8"?>' . "\r\n"];
+        yield 'standalone' => ['<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n"];
+        yield 'extra spaces' => ['<?xml  version="1.0"   encoding="UTF-8" ?>' . "\n"];
+    }
+
     protected function getFixture(string $name): string
     {
         return (string) file_get_contents(__DIR__ . '/../../../fixtures/' . $name);

--- a/tests/lib/EncoderTest.php
+++ b/tests/lib/EncoderTest.php
@@ -10,15 +10,21 @@ namespace Ibexa\Tests\AutomatedTranslation;
 
 use Ibexa\AutomatedTranslation\Encoder;
 use Ibexa\AutomatedTranslation\Encoder\Field\FieldEncoderManager;
+use Ibexa\AutomatedTranslation\Encoder\Field\RichTextFieldEncoder;
+use Ibexa\AutomatedTranslation\Encoder\Field\TextBlockFieldEncoder;
+use Ibexa\AutomatedTranslation\Encoder\Field\TextLineFieldEncoder;
+use Ibexa\AutomatedTranslation\Encoder\RichText\RichTextEncoder;
 use Ibexa\AutomatedTranslation\TextFieldCdataCleaner;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\FieldType\TextLine;
 use Ibexa\Core\Repository\Values\Content\Content;
 use Ibexa\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\FieldTypePage\FieldType\LandingPage\Value as LandingPageValue;
+use Ibexa\FieldTypeRichText\FieldType\RichText\Value as RichTextValue;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -119,6 +125,79 @@ XML;
         self::assertEquals($expectedEncodeResult, $encodeResult);
     }
 
+    public function testDecodeFakeCdataDoesNotPrependXmlDeclaration(): void
+    {
+        $subject = $this->createEncoderWithRealFieldEncoders();
+        $content = $this->createContent(['field_1_textline' => new TextLine\Value('Some text 1 & 2')]);
+
+        // the bare '&' parses only because decode() turns the faker tag into a CDATA section first
+        $payload = '<?xml version="1.0"?>
+<response><field_1_textline type="Ibexa\\Core\\FieldType\\TextLine\\Value"><fakecdata>Some text 1 & 2</fakecdata></field_1_textline></response>
+';
+
+        $result = $subject->decode($payload, $content);
+
+        self::assertStringNotContainsString('<?xml', (string) $result['field_1_textline']);
+        self::assertSame('Some text 1 & 2', (string) $result['field_1_textline']);
+    }
+
+    public function testEncodeTextLineWithSpecialCharactersIsWellFormed(): void
+    {
+        $subject = $this->createEncoderWithRealFieldEncoders();
+        $content = $this->createContent(['field_1_textline' => new TextLine\Value('Tom & Jerry <3')]);
+
+        $payload = $subject->encode($content);
+
+        self::assertStringNotContainsString('fakecdata', $payload);
+        self::assertStringContainsString('Tom &amp; Jerry &lt;3', $payload);
+        $this->assertWellFormedXml($payload);
+    }
+
+    /**
+     * @dataProvider provideSpecialCharacterValues
+     */
+    public function testEncodeDecodeRoundTripPreservesSpecialCharacters(string $value): void
+    {
+        $subject = $this->createEncoderWithRealFieldEncoders();
+        $content = $this->createContent(['field_1_textline' => new TextLine\Value($value)]);
+
+        $payload = $subject->encode($content);
+        $this->assertWellFormedXml($payload);
+
+        $result = $subject->decode($payload, $content);
+
+        self::assertSame($value, (string) $result['field_1_textline']);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public function provideSpecialCharacterValues(): iterable
+    {
+        yield 'ampersand' => ['Tom & Jerry'];
+        yield 'lower than' => ['a < b'];
+        yield 'greater than' => ['b > a'];
+        yield 'quotes' => ['He said "hi" and \'bye\''];
+        yield 'accented' => ['Café & crème'];
+        yield 'cyrillic' => ['Привет & мир'];
+        yield 'entity looking text' => ['5 &amp; 6'];
+        yield 'mixed' => ['Café <b>& "crème"</b> — Привет'];
+    }
+
+    public function testEncodeRichTextKeepsFakeCdata(): void
+    {
+        $subject = $this->createEncoderWithRealFieldEncoders();
+        $content = $this->createContent([
+            'field_1_richtext' => new RichTextValue($this->getFixture('testEncodeTwoRichText_field1_richtext.xml')),
+        ]);
+
+        $payload = $subject->encode($content);
+
+        self::assertStringContainsString('<fakecdata>', $payload);
+        self::assertStringNotContainsString('&lt;section', $payload);
+        $this->assertWellFormedXml($payload);
+    }
+
     public function testEncodePageFieldKeepsFakeCdata(): void
     {
         $blocksPayload = '<blocks><item key="1"><name>Code</name><attributes>'
@@ -191,6 +270,53 @@ XML;
             ]),
             'internalFields' => $fields,
         ]);
+    }
+
+    private function createEncoderWithRealFieldEncoders(): Encoder
+    {
+        $contentTypeServiceMock = $this->getContentTypeServiceMock();
+
+        $contentType = $this->getMockForAbstractClass(
+            ContentType::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['getFieldDefinition']
+        );
+        $fieldDefinition = $this->getMockBuilder(FieldDefinition::class)
+            ->setConstructorArgs([
+                [
+                    'fieldTypeIdentifier' => 'ezstring',
+                    'isTranslatable' => true,
+                ],
+            ])
+            ->getMockForAbstractClass();
+
+        $contentType
+            ->method('getFieldDefinition')
+            ->willReturn($fieldDefinition);
+
+        $contentTypeServiceMock
+            ->method('loadContentType')
+            ->willReturn($contentType);
+
+        $configResolverMock = $this->getMockBuilder(ConfigResolverInterface::class)->getMock();
+        $configResolverMock
+            ->method('getParameter')
+            ->willReturn([]);
+
+        return new Encoder(
+            $contentTypeServiceMock,
+            $this->getMockBuilder(EventDispatcherInterface::class)->getMock(),
+            new FieldEncoderManager([
+                new TextLineFieldEncoder(),
+                new TextBlockFieldEncoder(),
+                new RichTextFieldEncoder(new RichTextEncoder($configResolverMock)),
+            ]),
+            new TextFieldCdataCleaner()
+        );
     }
 
     /**

--- a/tests/lib/EncoderTest.php
+++ b/tests/lib/EncoderTest.php
@@ -18,11 +18,16 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\TextLine;
 use Ibexa\Core\Repository\Values\Content\Content;
 use Ibexa\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\FieldTypePage\FieldType\LandingPage\Value as LandingPageValue;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class EncoderTest extends TestCase
 {
+    use WellFormedXmlAssertionTrait;
+
+    private const LANGUAGE_CODE = 'eng-GB';
+
     public function testEncodeWithoutFields(): void
     {
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
@@ -112,6 +117,80 @@ XML;
 ';
 
         self::assertEquals($expectedEncodeResult, $encodeResult);
+    }
+
+    public function testEncodePageFieldKeepsFakeCdata(): void
+    {
+        $blocksPayload = '<blocks><item key="1"><name>Code</name><attributes>'
+            . '<content type="text">Tom &amp; Jerry</content>'
+            . '</attributes></item></blocks>';
+
+        $contentTypeServiceMock = $this->getContentTypeServiceMock();
+        $contentType = $this->getMockForAbstractClass(
+            ContentType::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['getFieldDefinition']
+        );
+        $fieldDefinition = $this->getMockBuilder(FieldDefinition::class)
+            ->setConstructorArgs([
+                [
+                    'fieldTypeIdentifier' => 'ezlandingpage',
+                    'isTranslatable' => true,
+                ],
+            ])
+            ->getMockForAbstractClass();
+
+        $contentType->method('getFieldDefinition')->willReturn($fieldDefinition);
+        $contentTypeServiceMock->method('loadContentType')->willReturn($contentType);
+
+        $fieldEncoderManagerMock = $this->getMockBuilder(FieldEncoderManager::class)->getMock();
+        $fieldEncoderManagerMock
+            ->method('encode')
+            ->withAnyParameters()
+            ->willReturn($blocksPayload);
+
+        $subject = new Encoder(
+            $contentTypeServiceMock,
+            $this->getMockBuilder(EventDispatcherInterface::class)->getMock(),
+            $fieldEncoderManagerMock,
+            new TextFieldCdataCleaner()
+        );
+
+        $payload = $subject->encode($this->createContent(['field_landing_page' => new LandingPageValue()]));
+
+        self::assertStringContainsString('<fakecdata>', $payload);
+        self::assertStringNotContainsString('&lt;blocks', $payload);
+        $this->assertWellFormedXml($payload);
+    }
+
+    /**
+     * @param array<string, \Ibexa\Core\FieldType\Value> $fieldValues
+     */
+    private function createContent(array $fieldValues): Content
+    {
+        $fields = [];
+        foreach ($fieldValues as $identifier => $value) {
+            $fields[] = new Field([
+                'fieldDefIdentifier' => $identifier,
+                'languageCode' => self::LANGUAGE_CODE,
+                'value' => $value,
+            ]);
+        }
+
+        return new Content([
+            'versionInfo' => new VersionInfo([
+                'contentInfo' => new ContentInfo([
+                    'id' => 1,
+                    'contentTypeId' => 123,
+                    'mainLanguageCode' => self::LANGUAGE_CODE,
+                ]),
+            ]),
+            'internalFields' => $fields,
+        ]);
     }
 
     /**

--- a/tests/lib/Stubs/LazyLoadingPageValueStub.php
+++ b/tests/lib/Stubs/LazyLoadingPageValueStub.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AutomatedTranslation\Stubs;
+
+use Ibexa\FieldTypePage\FieldType\LandingPage\Value as LandingPageValue;
+
+/**
+ * Stands in for the lazy loading proxy the Page field type resolves to at runtime, whose generated
+ * class name never matches the value class by name.
+ */
+final class LazyLoadingPageValueStub extends LandingPageValue
+{
+}

--- a/tests/lib/TextFieldCdataCleanerTest.php
+++ b/tests/lib/TextFieldCdataCleanerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AutomatedTranslation;
+
+use Ibexa\AutomatedTranslation\Exception\CdataCleanupFailedException;
+use Ibexa\AutomatedTranslation\TextFieldCdataCleaner;
+use Ibexa\FieldTypePage\FieldType\LandingPage\Value as LandingPageValue;
+use Ibexa\FieldTypeRichText\FieldType\RichText\Value as RichTextValue;
+use Ibexa\Tests\AutomatedTranslation\Stubs\LazyLoadingPageValueStub;
+use PHPUnit\Framework\TestCase;
+
+final class TextFieldCdataCleanerTest extends TestCase
+{
+    /**
+     * @dataProvider providePlainTextTypes
+     */
+    public function testClearRemovesCdataForPlainText(string $type): void
+    {
+        $subject = new TextFieldCdataCleaner();
+
+        $result = $subject->clear($this->buildPayload($type, '<![CDATA[Tom & Jerry <3]]>'));
+
+        self::assertStringNotContainsString('CDATA', $result);
+        self::assertStringContainsString('Tom &amp; Jerry &lt;3', $result);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public function providePlainTextTypes(): iterable
+    {
+        yield 'text line value' => ['Ibexa\Core\FieldType\TextLine\Value'];
+        yield 'text block value' => ['Ibexa\Core\FieldType\TextBlock\Value'];
+        yield 'page builder text attribute' => ['text'];
+        yield 'unknown type' => ['whatever'];
+    }
+
+    /**
+     * @dataProvider providePreservedTypes
+     */
+    public function testClearKeepsCdataForMarkupValues(string $type): void
+    {
+        $subject = new TextFieldCdataCleaner();
+
+        $result = $subject->clear(
+            $this->buildPayload($type, '<![CDATA[<section><para>lorem ipsum</para></section>]]>')
+        );
+
+        self::assertStringContainsString('<![CDATA[<section><para>lorem ipsum</para></section>]]>', $result);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public function providePreservedTypes(): iterable
+    {
+        yield 'rich text field' => [RichTextValue::class];
+        yield 'page field' => [LandingPageValue::class];
+        yield 'page builder richtext attribute' => ['richtext'];
+        yield 'lazy loading proxy of page value' => [LazyLoadingPageValueStub::class];
+    }
+
+    public function testClearRemovesCdataWhenTypeAttributeIsAbsent(): void
+    {
+        $subject = new TextFieldCdataCleaner();
+
+        $result = $subject->clear('<blocks><item><name><![CDATA[Code & Co]]></name></item></blocks>');
+
+        self::assertStringNotContainsString('CDATA', $result);
+        self::assertStringContainsString('Code &amp; Co', $result);
+    }
+
+    public function testClearOnlyTouchesCdataOfNonPreservedTypes(): void
+    {
+        $subject = new TextFieldCdataCleaner();
+
+        $payload = '<blocks><item key="1">'
+            . '<name><![CDATA[Code & Co]]></name>'
+            . '<attributes>'
+            . '<content type="text"><![CDATA[Tom & Jerry]]></content>'
+            . '<body type="richtext"><![CDATA[<section><para>lorem</para></section>]]></body>'
+            . '</attributes></item></blocks>';
+
+        $result = $subject->clear($payload);
+
+        self::assertStringContainsString('Code &amp; Co', $result);
+        self::assertStringContainsString('Tom &amp; Jerry', $result);
+        self::assertStringContainsString('<![CDATA[<section><para>lorem</para></section>]]>', $result);
+    }
+
+    public function testClearThrowsOnMalformedPayload(): void
+    {
+        $subject = new TextFieldCdataCleaner();
+
+        $this->expectException(CdataCleanupFailedException::class);
+
+        $subject->clear('<response><unclosed></response>');
+    }
+
+    private function buildPayload(string $type, string $content): string
+    {
+        return sprintf('<response><field type="%s">%s</field></response>', htmlspecialchars($type), $content);
+    }
+}

--- a/tests/lib/WellFormedXmlAssertionTrait.php
+++ b/tests/lib/WellFormedXmlAssertionTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AutomatedTranslation;
+
+use DOMDocument;
+use LibXMLError;
+
+trait WellFormedXmlAssertionTrait
+{
+    private function assertWellFormedXml(string $payload): void
+    {
+        $useInternalErrors = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        $loaded = (new DOMDocument())->loadXML($payload);
+        $errors = array_map(
+            static function (LibXMLError $error): string {
+                return trim($error->message);
+            },
+            libxml_get_errors()
+        );
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($useInternalErrors);
+
+        self::assertTrue(
+            $loaded,
+            sprintf("Payload is not well-formed XML:\n%s\n%s", $payload, implode("\n", $errors))
+        );
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-11802 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Special characters like & in block names and richtext block is not dealt with correctly with automated-translations.
Problem with special characters in field types was fixed in #29, but it [broke page builder block translations](https://github.com/ibexa/automated-translation/blob/v5.0.10/src/lib/TextFieldCdataCleaner.php#L64) as those values where no longer translated into `fakecdata` elements


Page Builder page fields and richtext block attributes now keep their CDATA (becomes `<fakecdata>/<fake_blocks_cdata>`) instead of being XML-escaped. Escaping stacked 2–3 levels deep (`&amp;amp;amp;`), DeepL and Google started rewriting the ampersands ( LLM responded in non-deterministic way so problem was not always reproducable), and decode died with `xmlParseEntityRef: no name` . Google tend do do the rewrite more frequently than DeepL.

<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
You can see ticket description for how to reproduce, but the problem doesn't always surface in the GUI. Once way to test this to enable logging. Cherry-pick the commit from https://github.com/ibexa/automated-translation/pull/45 and then see the difference between before and after fix:
Before
```
<?xml version="1.0"?>
<response>
    <name type="Ibexa\Core\FieldType\TextLine\Value">Landingpage with blockname and block containing &amp; special character</name>
    <description type="Ibexa\Core\FieldType\TextLine\Value">desc</description>
    <page type="ProxyManagerGeneratedProxy\__PM__\Ibexa\FieldTypePage\FieldType\LandingPage\Value\Generated31dda5577b48d8a239cc1b3dfbcb80bc">&lt;blocks&gt;&lt;item key="26937"&gt;&lt;name&gt;The company Father &amp;amp; son is doing well&lt;/name&gt;&lt;attributes&gt;&lt;content type="richtext"&gt;&amp;lt;section
        xmlns="http://docbook.org/ns/docbook"
        xmlns:xlink="http://www.w3.org/1999/xlink"
        xmlns:ezxhtml="http://ibexa.co/xmlns/dxp/docbook/xhtml"
        xmlns:ezcustom="http://ibexa.co/xmlns/dxp/docbook/custom" version="5.0-variant ezpublish-1.0"&amp;gt;&amp;lt;para&amp;gt;Here we have richtext content with &amp;amp;amp; and &amp;#x20AC; special char&amp;lt;/para&amp;gt;&amp;lt;/section&amp;gt;&amp;lt;XEOL /&amp;gt;&lt;/content&gt;&lt;/attributes&gt;&lt;/item&gt;&lt;/blocks&gt; 
    </page>
</response>
```

After
```
<?xml version="1.0"?>
<response>
    <name type="Ibexa\Core\FieldType\TextLine\Value">
        <fakecdata>Landingpage with blockname and block containing & special character</fakecdata>
    </name>
    <description type="Ibexa\Core\FieldType\TextLine\Value">desc</description>
    <page type="ProxyManagerGeneratedProxy\__PM__\Ibexa\FieldTypePage\FieldType\LandingPage\Value\Generated31dda5577b48d8a239cc1b3dfbcb80bc">
        <fakecdata>
            <blocks>
                <item key="26937">
                    <name>
                        <fake_blocks_cdata>The company Father & son is doing well</fake_blocks_cdata>
                    </name>
                    <attributes>
                        <content type="richtext">
                            <fake_blocks_cdata>
                                <section
                                    xmlns="http://docbook.org/ns/docbook"
                                    xmlns:xlink="http://www.w3.org/1999/xlink"
                                    xmlns:ezxhtml="http://ibexa.co/xmlns/dxp/docbook/xhtml"
                                    xmlns:ezcustom="http://ibexa.co/xmlns/dxp/docbook/custom" version="5.0-variant ezpublish-1.0">
                                    <para>Here we have richtext content with &amp; and € special char</para>
                                </section>
                                <XEOL />
                            </fake_blocks_cdata>
                        </content>
                    </attributes>
                </item>
            </blocks>
        </fakecdata>
    </page>
</response>
```

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
