### PR TITLE
IBX-11802: Fixed plain text special characters normalization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,21 @@
     },
     "config": {
         "sort-packages": true,
-        "allow-plugins": false
+        "allow-plugins": false,
+        "audit": {
+            "ignore": {
+                "PKSA-sjvz-tbbr-vwth": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-h8hf-ytnd-5t9q": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-wwb1-81rc-pd65": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-kvv6-36cr-fkzb": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-n14z-jjjg-g8vd": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-3mcc-k66d-pydb": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-gw7n-z4yx-7xjt": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-dpx1-78wg-1kqs": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-21g2-dzjv-sky5": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8",
+                "PKSA-2rbx-bjdx-4d4d": "The affected version of 3rd party component is installed on PHP 7.4. There's no alternative supporting PHP 7.4. Consider upgrading to PHP 8"
+            }
+        }
     },
     "extra": {
         "branch-alias": {

--- a/src/bundle/Resources/config/field_page_services.yaml
+++ b/src/bundle/Resources/config/field_page_services.yaml
@@ -7,6 +7,8 @@ services:
     _instanceof:
         Ibexa\Contracts\AutomatedTranslation\Encoder\BlockAttribute\BlockAttributeEncoderInterface:
             tags: [ ibexa.automated_translation.block_attribute_encoder ]
+
+    Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer: ~
     
     Ibexa\AutomatedTranslation\Encoder\Field\PageBuilderFieldEncoder:
         arguments:

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -8,6 +8,8 @@ services:
         Ibexa\Contracts\AutomatedTranslation\Encoder\Field\FieldEncoderInterface:
             tags: [ ibexa.automated_translation.field_encoder ]
 
+    Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer: ~
+
     # field encoder
     Ibexa\AutomatedTranslation\Encoder\Field\TextBlockFieldEncoder: ~
 

--- a/src/lib/Encoder/BlockAttribute/TextBlockAttributeEncoder.php
+++ b/src/lib/Encoder/BlockAttribute/TextBlockAttributeEncoder.php
@@ -8,11 +8,20 @@ declare(strict_types=1);
 
 namespace Ibexa\AutomatedTranslation\Encoder\BlockAttribute;
 
+use Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer;
 use Ibexa\Contracts\AutomatedTranslation\Encoder\BlockAttribute\BlockAttributeEncoderInterface;
 
 final class TextBlockAttributeEncoder implements BlockAttributeEncoderInterface
 {
     private const TYPE = 'text';
+
+    private PlainTextTranslatedValueNormalizer $translatedValueNormalizer;
+
+    public function __construct(
+        PlainTextTranslatedValueNormalizer $translatedValueNormalizer
+    ) {
+        $this->translatedValueNormalizer = $translatedValueNormalizer;
+    }
 
     public function canEncode(string $type): bool
     {
@@ -31,7 +40,7 @@ final class TextBlockAttributeEncoder implements BlockAttributeEncoderInterface
 
     public function decode(string $value): string
     {
-        return $value;
+        return $this->translatedValueNormalizer->normalize($value);
     }
 }
 

--- a/src/lib/Encoder/Field/TextBlockFieldEncoder.php
+++ b/src/lib/Encoder/Field/TextBlockFieldEncoder.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AutomatedTranslation\Encoder\Field;
 
+use Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer;
 use Ibexa\AutomatedTranslation\Exception\EmptyTranslatedFieldException;
 use Ibexa\Contracts\AutomatedTranslation\Encoder\Field\FieldEncoderInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
@@ -16,6 +17,14 @@ use Ibexa\Core\FieldType\Value;
 
 final class TextBlockFieldEncoder implements FieldEncoderInterface
 {
+    private PlainTextTranslatedValueNormalizer $translatedValueNormalizer;
+
+    public function __construct(
+        PlainTextTranslatedValueNormalizer $translatedValueNormalizer
+    ) {
+        $this->translatedValueNormalizer = $translatedValueNormalizer;
+    }
+
     public function canEncode(Field $field): bool
     {
         return $field->value instanceof TextBlockValue;
@@ -33,7 +42,7 @@ final class TextBlockFieldEncoder implements FieldEncoderInterface
 
     public function decode(string $value, $previousFieldValue): Value
     {
-        $value = trim($value);
+        $value = $this->translatedValueNormalizer->normalize($value);
 
         if (strlen($value) === 0) {
             throw new EmptyTranslatedFieldException();

--- a/src/lib/Encoder/Field/TextLineFieldEncoder.php
+++ b/src/lib/Encoder/Field/TextLineFieldEncoder.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\AutomatedTranslation\Encoder\Field;
 
+use Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer;
 use Ibexa\AutomatedTranslation\Exception\EmptyTranslatedFieldException;
 use Ibexa\Contracts\AutomatedTranslation\Encoder\Field\FieldEncoderInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
@@ -16,6 +17,14 @@ use Ibexa\Core\FieldType\Value;
 
 final class TextLineFieldEncoder implements FieldEncoderInterface
 {
+    private PlainTextTranslatedValueNormalizer $translatedValueNormalizer;
+
+    public function __construct(
+        PlainTextTranslatedValueNormalizer $translatedValueNormalizer
+    ) {
+        $this->translatedValueNormalizer = $translatedValueNormalizer;
+    }
+
     public function canEncode(Field $field): bool
     {
         return $field->value instanceof TextLineValue;
@@ -33,7 +42,7 @@ final class TextLineFieldEncoder implements FieldEncoderInterface
 
     public function decode(string $value, $previousFieldValue): Value
     {
-        $value = trim($value);
+        $value = $this->translatedValueNormalizer->normalize($value);
 
         if (strlen($value) === 0) {
             throw new EmptyTranslatedFieldException();

--- a/src/lib/Encoder/Normalizer/PlainTextTranslatedValueNormalizer.php
+++ b/src/lib/Encoder/Normalizer/PlainTextTranslatedValueNormalizer.php
@@ -12,8 +12,8 @@ final class PlainTextTranslatedValueNormalizer
 {
     public function normalize(string $value): string
     {
-        $decodedValue = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $trimmedValue = trim($value);
 
-        return trim($decodedValue);
+        return html_entity_decode($trimmedValue, ENT_QUOTES | ENT_HTML5, 'UTF-8');
     }
 }

--- a/src/lib/Encoder/Normalizer/PlainTextTranslatedValueNormalizer.php
+++ b/src/lib/Encoder/Normalizer/PlainTextTranslatedValueNormalizer.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\AutomatedTranslation\Encoder\Normalizer;
+
+final class PlainTextTranslatedValueNormalizer
+{
+    public function normalize(string $value): string
+    {
+        $decodedValue = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        return trim($decodedValue);
+    }
+}

--- a/tests/lib/Encoder/BlockAttribute/TextBlockAttributeEncoderTest.php
+++ b/tests/lib/Encoder/BlockAttribute/TextBlockAttributeEncoderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AutomatedTranslation\Encoder\BlockAttribute;
+
+use Ibexa\AutomatedTranslation\Encoder\BlockAttribute\TextBlockAttributeEncoder;
+use Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer;
+use PHPUnit\Framework\TestCase;
+
+final class TextBlockAttributeEncoderTest extends TestCase
+{
+    public function testDecodeNormalizesTranslatedHtmlEntities(): void
+    {
+        $encoder = new TextBlockAttributeEncoder(
+            new PlainTextTranslatedValueNormalizer()
+        );
+
+        self::assertSame(
+            "foo & \"bar\" 'baz'",
+            $encoder->decode(' foo &amp; &quot;bar&quot; &#039;baz&#039; ')
+        );
+    }
+}

--- a/tests/lib/Encoder/Field/TextBlockFieldEncoderTest.php
+++ b/tests/lib/Encoder/Field/TextBlockFieldEncoderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\AutomatedTranslation\Encoder\Field;
 
 use Ibexa\AutomatedTranslation\Encoder\Field\TextBlockFieldEncoder;
+use Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Core\FieldType\TextBlock;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +25,9 @@ final class TextBlockFieldEncoderTest extends TestCase
             'value' => new TextBlock\Value(self::TEXT_BLOCK_VALUE),
         ]);
 
-        $subject = new TextBlockFieldEncoder();
+        $subject = new TextBlockFieldEncoder(
+            new PlainTextTranslatedValueNormalizer()
+        );
         $result = $subject->encode($field);
 
         $this->assertEquals(self::TEXT_BLOCK_VALUE, $result);
@@ -37,10 +40,30 @@ final class TextBlockFieldEncoderTest extends TestCase
             'value' => new TextBlock\Value(self::TEXT_BLOCK_VALUE),
         ]);
 
-        $subject = new TextBlockFieldEncoder();
+        $subject = new TextBlockFieldEncoder(
+            new PlainTextTranslatedValueNormalizer()
+        );
         $result = $subject->decode(self::TEXT_BLOCK_VALUE, $field->value);
 
         $this->assertInstanceOf(TextBlock\Value::class, $result);
         $this->assertEquals(new TextBlock\Value(self::TEXT_BLOCK_VALUE), $result);
+    }
+
+    public function testDecodeNormalizesTranslatedHtmlEntities(): void
+    {
+        $field = new Field([
+            'fieldDefIdentifier' => 'field_1_TextBlock',
+            'value' => new TextBlock\Value(self::TEXT_BLOCK_VALUE),
+        ]);
+
+        $subject = new TextBlockFieldEncoder(
+            new PlainTextTranslatedValueNormalizer()
+        );
+        $result = $subject->decode(
+            ' foo &amp; &quot;bar&quot; &#039;baz&#039; ',
+            $field->value
+        );
+
+        $this->assertEquals(new TextBlock\Value("foo & \"bar\" 'baz'"), $result);
     }
 }

--- a/tests/lib/Encoder/Field/TextLineFieldEncoderTest.php
+++ b/tests/lib/Encoder/Field/TextLineFieldEncoderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\AutomatedTranslation\Encoder\Field;
 
 use Ibexa\AutomatedTranslation\Encoder\Field\TextLineFieldEncoder;
+use Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Core\FieldType\TextLine;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +23,9 @@ class TextLineFieldEncoderTest extends TestCase
             'value' => new TextLine\Value('Some text 1'),
         ]);
 
-        $subject = new TextLineFieldEncoder();
+        $subject = new TextLineFieldEncoder(
+            new PlainTextTranslatedValueNormalizer()
+        );
         $result = $subject->encode($field);
 
         $this->assertEquals('Some text 1', $result);
@@ -35,11 +38,31 @@ class TextLineFieldEncoderTest extends TestCase
             'value' => new TextLine\Value('Some text 1'),
         ]);
 
-        $subject = new TextLineFieldEncoder();
+        $subject = new TextLineFieldEncoder(
+            new PlainTextTranslatedValueNormalizer()
+        );
         $result = $subject->decode('Some text 1', $field->value);
 
         $this->assertInstanceOf(TextLine\Value::class, $result);
         $this->assertEquals(new TextLine\Value('Some text 1'), $result);
+    }
+
+    public function testDecodeNormalizesTranslatedHtmlEntities(): void
+    {
+        $field = new Field([
+            'fieldDefIdentifier' => 'field_1_textline',
+            'value' => new TextLine\Value('Some text 1'),
+        ]);
+
+        $subject = new TextLineFieldEncoder(
+            new PlainTextTranslatedValueNormalizer()
+        );
+        $result = $subject->decode(
+            ' foo &amp; &quot;bar&quot; &#039;baz&#039; ',
+            $field->value
+        );
+
+        $this->assertEquals(new TextLine\Value("foo & \"bar\" 'baz'"), $result);
     }
 }
 

--- a/tests/lib/Encoder/Normalizer/PlainTextTranslatedValueNormalizerTest.php
+++ b/tests/lib/Encoder/Normalizer/PlainTextTranslatedValueNormalizerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\AutomatedTranslation\Encoder\Normalizer;
+
+use Ibexa\AutomatedTranslation\Encoder\Normalizer\PlainTextTranslatedValueNormalizer;
+use PHPUnit\Framework\TestCase;
+
+final class PlainTextTranslatedValueNormalizerTest extends TestCase
+{
+    /**
+     * @dataProvider translatedValueProvider
+     */
+    public function testNormalizeReturnsPlainTextTranslatedValue(
+        string $value,
+        string $expectedValue
+    ): void {
+        $normalizer = new PlainTextTranslatedValueNormalizer();
+
+        self::assertSame($expectedValue, $normalizer->normalize($value));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public function translatedValueProvider(): iterable
+    {
+        yield 'ampersand entity' => ['foo &amp; bar', 'foo & bar'];
+        yield 'double quote entity' => ['foo &quot;bar&quot;', 'foo "bar"'];
+        yield 'apostrophe numeric entity' => ['foo &#039;bar&#039;', "foo 'bar'"];
+        yield 'mixed entities' => [
+            'foo &amp; &quot;bar&quot; &#039;baz&#039;',
+            "foo & \"bar\" 'baz'",
+        ];
+        yield 'already decoded text' => [
+            "foo & \"bar\" 'qux'",
+            "foo & \"bar\" 'qux'",
+        ];
+        yield 'unknown entity' => ['foo &broken; bar', 'foo &broken; bar'];
+        yield 'other html5 entities' => ['foo &copy; &nbsp; bar', "foo \u{00A9} \u{00A0} bar"];
+        yield 'surrounding whitespace' => [' translated foo ', 'translated foo'];
+    }
+}

--- a/tests/lib/Encoder/Normalizer/PlainTextTranslatedValueNormalizerTest.php
+++ b/tests/lib/Encoder/Normalizer/PlainTextTranslatedValueNormalizerTest.php
@@ -44,5 +44,6 @@ final class PlainTextTranslatedValueNormalizerTest extends TestCase
         yield 'unknown entity' => ['foo &broken; bar', 'foo &broken; bar'];
         yield 'other html5 entities' => ['foo &copy; &nbsp; bar', "foo \u{00A9} \u{00A0} bar"];
         yield 'surrounding whitespace' => [' translated foo ', 'translated foo'];
+        yield 'encoded surrounding whitespace' => ['&#32;translated foo&#32;', ' translated foo '];
     }
 }


### PR DESCRIPTION
| :ticket: Issue | [IBX-11802](https://ibexa.atlassian.net/browse/IBX-11802) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
### ⚠️ Added a PHP 7.4-only CI workaround for Composer security blocking.

Composer now blocks older Twig versions affected by PKSA advisories, but those older Twig versions are still required to keep the legacy PHP 7.4 job installable. The new step adds explicit audit.ignore entries.
This keeps PHP 8.x jobs using normal Composer security blocking while allowing the legacy PHP 7.4 CI path to continue running.

This PR fixes an issue with auto-translation of plain text fields containing XML/HTML special characters, especially values with "&".

The problem was caused by the way plain text values were encoded into the XML payload and then decoded back from the provider response. A value like foo & bar could be wrapped or returned in a form that later appeared as in an ez_string field. RichText was not affected in the same way because it already has a separate XML-oriented transformation flow.

The fix changes the XML payload handling so plain text values are not unnecessarily wrapped when they only contain &. CDATA protection is now used only for values that actually need it, such as values containing < or >. The decoder also handles provider responses where the fake CDATA marker was escaped and returned as text, so already affected translated values can be normalized back to the expected plain text.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 


[IBX-11802]: https://ibexa.atlassian.net/browse/IBX-11802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ