### PR TITLE
Fixed translations

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -10,13 +10,13 @@ on:
 jobs:
     cs-fix:
         name: Run code style check
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-26.04"
         strategy:
             matrix:
                 php:
                     - '8.1'
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:
@@ -30,7 +30,7 @@ jobs:
 
     tests:
         name: Tests
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-26.04"
         timeout-minutes: 10
 
         strategy:
@@ -42,7 +42,7 @@ jobs:
                     - '8.3'
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@v7
 
             -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:

--- a/src/bundle/Form/Extension/LanguageCreateType.php
+++ b/src/bundle/Form/Extension/LanguageCreateType.php
@@ -39,7 +39,7 @@ class LanguageCreateType extends AbstractTypeExtension
             'languageCode',
             ChoiceType::class,
             [
-                'label' => /* @Desc("Language code") */ 'ibexa.language.create.language_code',
+                'label' => /** @Desc("Language code") */ 'ibexa.language.create.language_code',
                 'required' => false,
                 'choices' => array_combine($this->localeList, $this->localeList),
                 'translation_domain' => 'ibexa_automated_translation',


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-XXXXX](https://issues.ibexa.co/browse/IBX-XXXXX)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 4.6
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The `@Desc("Language code")` annotation was in a single-star comment `/* */` instead of a docblock `/** */`. The JMS extractor only reads docblock comments, so the source text was falling back to the translation key. Changed to `/** @Desc("Language code") */`.